### PR TITLE
Fix SwiftPM builds on non-Apple platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,8 @@ let package = Package(
         .testTarget(
             name: "XColorTests",
             dependencies: ["XColor"],
-            path: "XColorTests"
+            path: "XColorTests",
+            exclude: ["Info.plist"]
         )
     ]
 )

--- a/Source/UIColor+Hex.swift
+++ b/Source/UIColor+Hex.swift
@@ -6,38 +6,39 @@
 //  Copyright © 2019 Jaume Viñas Navas. All rights reserved.
 //
 
-#if os(macOS)
-import Cocoa
+#if canImport(AppKit)
+import AppKit
 typealias OSColor = NSColor
-#else
+#elseif canImport(UIKit)
 import UIKit
 typealias OSColor = UIColor
 #endif
 
+#if canImport(AppKit) || canImport(UIKit)
 extension OSColor {
     private convenience init?(xColor: XColor) {
         guard let components = xColor.components else { return nil }
         self.init(red: CGFloat(components.red) / 255, green: CGFloat(components.green) / 255, blue: CGFloat(components.blue) / 255, alpha: CGFloat(components.alpha))
     }
-    
+
     public convenience init?(_ hex: String) {
         guard let xc = XColor(hexColor: hex) else { return nil }
         self.init(xColor: xc)
     }
-    
+
     public convenience init?(_ hex: String, alpha: Double) {
         guard let xc = XColor(hexColor: hex, alpha: alpha) else { return nil }
         self.init(xColor: xc)
     }
-    
+
     public convenience init?(_ hex: Int) {
         guard let xc = XColor(hexColor: hex) else { return nil }
         self.init(xColor: xc)
     }
-    
+
     public convenience init?(_ hex: Int, alpha: Double) {
         guard let xc = XColor(hexColor: hex, alpha: alpha) else { return nil }
         self.init(xColor: xc)
     }
-    
 }
+#endif

--- a/XColorTests/UIColorTests.swift
+++ b/XColorTests/UIColorTests.swift
@@ -9,8 +9,13 @@
 import XCTest
 
 #if SWIFT_PACKAGE
-import Cocoa
+#if canImport(AppKit)
+import AppKit
 @testable import XColor
+#elseif canImport(UIKit)
+import UIKit
+@testable import XColor
+#endif
 #elseif os(iOS)
 import UIKit
 @testable import XColor_iOS
@@ -22,52 +27,53 @@ import Cocoa
 @testable import XColor_macOS
 #endif
 
+#if canImport(AppKit) || canImport(UIKit)
 class UIColorTests: XCTestCase {
     func testColorWithString() {
         // GIVEN
         let hex = "#AC34CF"
-        
+
         // WHEN
         let color = OSColor(hex)
-        
+
         // EXPECT
         let components = color?.rgba
-        
+
         XCTAssertEqual(color?.cgColor.numberOfComponents, 4 , "Color should have three color components and alpha channel")
         XCTAssertEqual(components?.red, 0xAC / 255 , "Red component should be 0xAC")
         XCTAssertEqual(components?.green, 0x34 / 255 , "Green component should be 0x34")
         XCTAssertEqual(components?.blue, 0xCF / 255 , "Blue component should be 0xCF")
         XCTAssertEqual(components?.alpha, 0xFF / 255 , "Alpha component should be 0xFF")
     }
-    
+
     func testColorWithStringAndImplicitAlphaChannel() {
         // GIVEN
         let hex = "#AC34CF88"
-        
+
         // WHEN
         let color = OSColor(hex)
-        
+
         // EXPECT
         let components = color?.rgba
-        
+
         XCTAssertEqual(color?.cgColor.numberOfComponents, 4 , "Color should have three color components and alpha channel")
         XCTAssertEqual(components?.red, 0xAC / 255 , "Red component should be 0xAC")
         XCTAssertEqual(components?.green, 0x34 / 255 , "Green component should be 0x34")
         XCTAssertEqual(components?.blue, 0xCF / 255 , "Blue component should be 0xCF")
         XCTAssertEqual(components?.alpha, 0x88 / 255 , "Alpha component should be 0x88")
     }
-    
+
     func testColorWithStringAndExplicitAlphaChannel() {
         // GIVEN
         let hex = "#AC34CF"
         let alpha = 0.3
-        
+
         // WHEN
         let color = OSColor(hex, alpha: alpha)
-        
+
         // EXPECT
         let components = color?.rgba
-        
+
         XCTAssertEqual(color?.cgColor.numberOfComponents, 4 , "Color should have three color components and alpha channel")
         XCTAssertEqual(components?.red, 0xAC / 255 , "Red component should be 0xAC")
         XCTAssertEqual(components?.green, 0x34 / 255 , "Green component should be 0x34")
@@ -78,48 +84,48 @@ class UIColorTests: XCTestCase {
     func testColorWithNumber() {
         // GIVEN
         let hex = 0xAC34CF
-        
+
         // WHEN
         let color = OSColor(hex)
-        
+
         // EXPECT
         let components = color?.rgba
-        
+
         XCTAssertEqual(color?.cgColor.numberOfComponents, 4 , "Color should have three color components and alpha channel")
         XCTAssertEqual(components?.red, 0xAC / 255 , "Red component should be 0xAC")
         XCTAssertEqual(components?.green, 0x34 / 255 , "Green component should be 0x34")
         XCTAssertEqual(components?.blue, 0xCF / 255 , "Blue component should be 0xCF")
         XCTAssertEqual(components?.alpha, 0xFF / 255 , "Alpha component should be 0xFF")
     }
-    
+
     func testColorWithNumberAndImplicitAlphaChannel() {
         // GIVEN
         let hex = 0xAC34CF88
-        
+
         // WHEN
         let color = OSColor(hex)
-        
+
         // EXPECT
         let components = color?.rgba
-        
+
         XCTAssertEqual(color?.cgColor.numberOfComponents, 4 , "Color should have three color components and alpha channel")
         XCTAssertEqual(components?.red, 0xAC / 255 , "Red component should be 0xAC")
         XCTAssertEqual(components?.green, 0x34 / 255 , "Green component should be 0x34")
         XCTAssertEqual(components?.blue, 0xCF / 255 , "Blue component should be 0xCF")
         XCTAssertEqual(components?.alpha, 0x88 / 255 , "Alpha component should be 0x88")
     }
-    
+
     func testColorWithNumberAndExplicitAlphaChannel() {
         // GIVEN
         let hex = 0xAC34CF
         let alpha = 0.3
-        
+
         // WHEN
         let color = OSColor(hex, alpha: alpha)
-        
+
         // EXPECT
         let components = color?.rgba
-        
+
         XCTAssertEqual(color?.cgColor.numberOfComponents, 4 , "Color should have three color components and alpha channel")
         XCTAssertEqual(components?.red, 0xAC / 255 , "Red component should be 0xAC")
         XCTAssertEqual(components?.green, 0x34 / 255 , "Green component should be 0x34")
@@ -130,11 +136,12 @@ class UIColorTests: XCTestCase {
     func testColorWithInvalidString() {
         // GIVEN
         let hex = ".This is an invalid string!"
-        
+
         // WHEN
         let color = OSColor(hex)
-        
+
         // EXPECT
         XCTAssertNil(color)
     }
 }
+#endif

--- a/XColorTests/Utils/UIColor+Helpers.swift
+++ b/XColorTests/Utils/UIColor+Helpers.swift
@@ -6,13 +6,13 @@
 //  Copyright © 2019 Jaume Viñas Navas. All rights reserved.
 //
 
-#if os(macOS)
-import Cocoa
-#else
+#if canImport(AppKit)
+import AppKit
+#elseif canImport(UIKit)
 import UIKit
 #endif
 
-
+#if canImport(AppKit) || canImport(UIKit)
 extension OSColor {
     var rgba: (red: CGFloat, green: CGFloat, blue: CGFloat, alpha: CGFloat) {
         var red: CGFloat = 0
@@ -20,7 +20,8 @@ extension OSColor {
         var blue: CGFloat = 0
         var alpha: CGFloat = 0
         getRed(&red, green: &green, blue: &blue, alpha: &alpha)
-        
+
         return (red, green, blue, alpha)
     }
 }
+#endif

--- a/XColorTests/XColorTests.swift
+++ b/XColorTests/XColorTests.swift
@@ -7,8 +7,6 @@
 //
 
 import XCTest
-import CoreGraphics
-
 #if SWIFT_PACKAGE
 @testable import XColor
 #elseif os(iOS)


### PR DESCRIPTION
### Motivation
- Make the package build and run tests under SwiftPM on non-Apple platforms by avoiding unconditional `UIKit`/`CoreGraphics` imports and guarding Apple-only code.

### Description
- Use `#if canImport(AppKit)` / `#elseif canImport(UIKit)` for platform imports and `OSColor` typealias in `Source/UIColor+Hex.swift` so the library source compiles when AppKit/UIKit are not available.
- Wrap the `OSColor` extension in `#if canImport(AppKit) || canImport(UIKit)` so those convenience initializers are only compiled on supported platforms.
- Update `XColorTests/UIColorTests.swift` to conditionally import AppKit/UIKit under SwiftPM and guard the `UIColor`/`NSColor`-specific test class with `canImport` checks.
- Update `XColorTests/Utils/UIColor+Helpers.swift` to use `canImport` guards and wrap the `OSColor` helper extension accordingly, and remove the unnecessary `import CoreGraphics` from `XColorTests/XColorTests.swift` which caused failures on Linux.

### Testing
- Reproduced initial failures with `swift test` due to `no such module 'UIKit'` and later `no such module 'CoreGraphics'` before changes.
- After applying the `canImport` guards and removing the Linux-incompatible import, ran `swift test` on `x86_64-unknown-linux-gnu` and all tests passed with `Executed 11 tests, with 0 failures`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb7887b6188320bf7021ad9960308c)